### PR TITLE
improving dev experiece

### DIFF
--- a/_internal/_framework.h
+++ b/_internal/_framework.h
@@ -44,8 +44,8 @@ struct TestEnvironment
 
   _TestSelect selection;
 
-  void* helperPointer;
-  void* helperBlock[_TEST_HELPER_BLOCK_SIZE];
+  void* _helperBlockIndex;
+  void* helperMemoryBlock[_TEST_HELPER_BLOCK_SIZE];
 };
 
 struct FunctionMock
@@ -412,6 +412,7 @@ int _testFileMain(int numArgs, char** args, int (*_allTests)())
     signal(signals[i], _defaultRaiseHandler);
 
   _testEnv = (TestEnvironment){0};
+  _testEnv._helperBlockIndex = &_testEnv.helperMemoryBlock[0];
   _testEnv.testContext = _C_STRING_LITERAL("global");
   _testEnv.testDescription = _C_STRING_LITERAL("setup");
   int _testCount = _allTests();
@@ -419,6 +420,7 @@ int _testFileMain(int numArgs, char** args, int (*_allTests)())
   if(snapShot) free(snapShot);
   
   _testEnv = (TestEnvironment){0};
+  _testEnv._helperBlockIndex = &_testEnv.helperMemoryBlock[0];
   _testEnv.testContext = _C_STRING_LITERAL("global");
   _testEnv.testDescription = _C_STRING_LITERAL("setup");
   _testEnv.selection = _getArgsSelection(numArgs, args);

--- a/_internal/_macros.h
+++ b/_internal/_macros.h
@@ -48,9 +48,11 @@ extern "C"
 #define 🐛 beginTests
 #define 🚀 endTests
 
-#define _TEST_HELPER_BLOCK_SIZE 1024
+#define _TEST_HELPER_BLOCK_SIZE 10240
 #define assert(boolean) _assert(_C_STRING_LITERAL(__FILE__), __LINE__, boolean, _C_STRING_LITERAL(#boolean))
+#define assert_called(mockedFunction) assert(mockCalled(mockedFunction) > 0)
 #define refute(boolean) _assert(_C_STRING_LITERAL(__FILE__), __LINE__, !(boolean), _C_STRING_LITERAL(#boolean))
+#define refute_called(mockedFunction) assert(mockCalled(mockedFunction) == 0)
 
 #define beginTests \
   int _allTests(){ int _testCount = 0; int _testRunning = 0; int _testDefinition = 0; {
@@ -77,7 +79,7 @@ extern "C"
 
 #define mockGetOrginal(function) _getMock(_C_STRING_LITERAL(__FILE__), __LINE__, _C_STRING_LITERAL(#function), _mocks)->original
 
-#define helperBlockAs(env, type, index) (type*)&(((char*)env->helperBlock)[sizeof(type)*index])
+#define testAlloc(type) (type*)(testEnv->_helperBlockIndex += sizeof(type), testEnv->_helperBlockIndex - sizeof(type))
 
 #define endTests _finishLastScope() return _testCount; }\
   int main(int numArgs, char** args){\


### PR DESCRIPTION
Now you can allocate stack memory for your tests just by calling:
 ```type* type = testAlloc(type)```
Now you can assert a mock was called at least once by calling:
```assert_called(mockFunction) // (you can also use the refute_called version)```